### PR TITLE
Draft: Add a new class that encapsulates lengths

### DIFF
--- a/src/main/java/inspired/pdf/unbox/Length.java
+++ b/src/main/java/inspired/pdf/unbox/Length.java
@@ -1,0 +1,70 @@
+package inspired.pdf.unbox;
+
+import java.util.Objects;
+
+public final class Length {
+
+
+    /**
+     * The value of the length. PDFBox uses values that are
+     * 1/72 inch when no UserUnit is set.
+     */
+    private final float value;
+
+    private static final float UNITS_PER_INCH = 72;
+    private static final float UNITS_PER_MM = UNITS_PER_INCH / 25.4f;
+
+
+    private Length(float value) {
+        this.value = value;
+    }
+
+    public static Length mm(float mmValue) {
+        return new Length(mmValue * UNITS_PER_MM);
+    }
+
+    public static Length inch(float inchValue) {
+        return new Length(inchValue * UNITS_PER_INCH);
+    }
+
+    static Length fromPdf(float pdfValue) {
+        return new Length(pdfValue);
+    }
+
+    public float asMM() {
+        return value / UNITS_PER_MM;
+    }
+
+    public float asInch() {
+        return value / UNITS_PER_INCH;
+    }
+
+    float getValue() {
+        return value;
+    }
+
+    public Length add(Length length) {
+        return new Length(this.value + length.value);
+    }
+
+    public Length subtract(Length length) {
+        return new Length(this.value - length.value);
+    }
+
+    public String toString() {
+        return String.format("[%s mm]", asMM());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Length length = (Length) o;
+        return Float.compare(length.value, value) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/test/java/inspired/pdf/unbox/LengthTest.java
+++ b/src/test/java/inspired/pdf/unbox/LengthTest.java
@@ -1,0 +1,82 @@
+package inspired.pdf.unbox;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LengthTest {
+
+    @Test
+    void fromMM() {
+        var length = Length.mm(10f);
+        assertEquals(28.346458f, length.getValue());
+    }
+
+    @Test
+    void fromInch() {
+        var length = Length.inch(10f);
+        assertEquals(720f, length.getValue());
+    }
+
+    @Test
+    void mmIsCalculatedToAndFromPdfValue() {
+        var length = Length.mm(10f);
+        assertNotEquals(10f, length.getValue());
+        assertEquals(10f, length.asMM());
+    }
+
+    @Test
+    void inchIsCalculatedToAndFromPdfValue() {
+        var length = Length.inch(10f);
+        assertNotEquals(10f, length.getValue());
+        assertEquals(10f, length.asInch());
+    }
+
+    @Test
+    void getValueReturnsPdfValue() {
+        var length = Length.fromPdf(10f);
+        assertEquals(10f, length.getValue());
+    }
+
+    @Test
+    void lengthAreEqualIfValueIsEqual() {
+        var a = Length.mm(10f);
+        var b = Length.mm(10f);
+        assertEquals(a, b);
+    }
+
+    @Test
+    void addCanAddTwoPositiveLengths() {
+        var a = Length.mm(10f);
+        var b = Length.mm(5f);
+        assertEquals(Length.mm(15f), a.add(b));
+    }
+
+    @Test
+    void addCanAddPositiveAndNegativeLengths() {
+        var a = Length.mm(10f);
+        var b = Length.mm(-5f);
+        assertEquals(Length.mm(5f), a.add(b));
+    }
+
+    @Test
+    void subtractCanSubtractTwoPositiveLengths() {
+        var a = Length.mm(10f);
+        var b = Length.mm(5f);
+        assertEquals(Length.mm(5f), a.subtract(b));
+    }
+
+    @Test
+    void subtractCanSubtractPositiveAndNegativeLengths() {
+        var a = Length.mm(10f);
+        var b = Length.mm(-5f);
+        assertEquals(Length.mm(15f), a.subtract(b));
+    }
+
+    @Test
+    void testToString() {
+        var length = Length.mm(10f);
+        var s = length.toString();
+        assertEquals("[10.0 mm]", s);
+    }
+}


### PR DESCRIPTION
PDFBox uses an internal unit for measuring lengths that is 1/72 of an inch. If one designs forms or other documents, it can be helpful to be able to define lengths in other units like mm or inchs. For this a new class Length is added that allows to convert across different measurement units.
At a later point in time, we might consider using Length within unbox-pdf in all places where we keep lengths and calculate with them.
This pull request contains only the fundamental Length class. The class itself is currently not used.